### PR TITLE
Support for keeping secrets in S3 instead of on local disk

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -18,3 +18,6 @@ var/
 
 # Serverless directories
 .serverless
+
+# node_modules
+node_modules

--- a/dists/slscrypt/index.js
+++ b/dists/slscrypt/index.js
@@ -5,19 +5,48 @@ const AWS = require('aws-sdk');
 
 const SECRET_FILE = '.serverless-secret.json';
 
+const aws = require('aws-sdk')
+
+function file_data(location, cb) {
+  return fs.readFile(location, 'utf8', cb)
+}
+
+function s3_data(location, cb) {
+  let matches = location.match(/s3:\/\/([^\/]*)\/(.*$)/);
+  let bucket = matches[1];
+  let key = matches[2]
+  let s3 = new aws.S3({apiVersion: '2006-03-01', signatureVersion: 'v4'});
+  s3.getObject({ 'Bucket': bucket, 'Key': key }, function(err, data) {
+    if(err) cb(err, data);
+    else cb(err, data.Body)
+  });
+}
+
+function data(location, cb) {
+  if(location.startsWith('s3://')) {
+    return s3_data(location, cb);
+  } else if(location.startsWith('file://')) {
+    return file_data(location.substring(7), cb);
+  } else {
+    return file_data(location, cb);
+  }
+}
+
 module.exports = {
-  get(name) {
-    const secret = JSON.parse(fs.readFileSync(SECRET_FILE, 'utf-8'));
-    const kms = new AWS.KMS({ region: secret['__slscrypt-region'] });
+  get(name, location) {
     return new Promise((resolve, reject) => {
-      kms.decrypt({
-        CiphertextBlob: new Buffer(secret[name], 'base64'),
-      }, (err, data) => {
-        if (err) {
-          reject(err);
-        }
-        resolve(data.Plaintext.toString('utf-8'));
-      });
+      data(location, function(err, data) { 
+        const secret = JSON.parse(data));
+        const kms = new AWS.KMS({ region: secret['__slscrypt-region'] });
+        kms.decrypt({
+          CiphertextBlob: new Buffer(secret[name], 'base64'),
+        }, (err, data) => {
+          if (err) {
+            reject(err);
+          }
+          resolve(data.Plaintext.toString('utf-8'));
+        });
+      })
     });
   },
 };

--- a/index.js
+++ b/index.js
@@ -8,14 +8,14 @@ const saveSecret = require('./lib/saveSecret');
 const addLibraries = require('./lib/addLibraries');
 const removeLibraries = require('./lib/removeLibraries');
 
-const SECRET_FILE = '.serverless-secret.json';
+const SECRET_LOCATION = 'file://.serverless-secret.json';
 
 class Crypt {
   constructor(serverless, options) {
     this.serverless = serverless;
     this.options = options || {};
     this.provider = this.serverless.getProvider('aws');
-    this.secret_file = SECRET_FILE;
+    this.secret_location = options.location || options.l || SECRET_LOCATION;
 
     Object.assign(
       this,
@@ -34,6 +34,11 @@ class Crypt {
           'encrypt',
         ],
         options: {
+          location: {
+            usage: 'URL to storage, supported URI formats are file:// and s3://, no specifier is assumed to be a file path',
+            shortcut: 'l',
+            required: false
+          },
           name: {
             usage: 'Name of the secert',
             shortcut: 'n',
@@ -44,7 +49,7 @@ class Crypt {
             shortcut: 't',
           },
           save: {
-            usage: `Save the encrypted secret (to ${SECRET_FILE}`,
+            usage: `Save the encrypted secret (to ${this.secret_location}`,
           },
         },
       },
@@ -54,6 +59,11 @@ class Crypt {
           'decrypt',
         ],
         options: {
+          location: {
+            usage: `URL to storage, supported are file:/// and s3://, defaults to ${SECRET_LOCATION}`,
+            shortcut: 'l',
+            required: false
+          },
           name: {
             usage: 'Name of the secert',
             shortcut: 'n',

--- a/lib/decrypt.js
+++ b/lib/decrypt.js
@@ -1,22 +1,54 @@
 'use strict';
 
 const fs = require('fs');
+const aws = require('aws-sdk')
+
+function file_data(location, cb) {
+  return fs.readFile(location, 'utf8', cb)
+}
+
+function s3_data(location, cb) {
+  let matches = location.match(/s3:\/\/([^\/]*)\/(.*$)/);
+  let bucket = matches[1];
+  let key = matches[2]
+  let s3 = new aws.S3({apiVersion: '2006-03-01', signatureVersion: 'v4'});
+  s3.getObject({ 'Bucket': bucket, 'Key': key }, function(err, data) {
+    if(err) cb(err, data);
+    else cb(err, data.Body)
+  });
+}
+
+function data(location, cb) {
+  if(location.startsWith('s3://')) {
+    return s3_data(location, cb);
+  } else if(location.startsWith('file://')) {
+    return file_data(location.substring(7), cb);
+  } else {
+    return file_data(location, cb);
+  }
+}
 
 module.exports = {
   decrypt() {
-    const secrets = JSON.parse(fs.readFileSync(this.secret_file, 'utf8'));
+    let _this = this;
+    return data(_this.secret_location, function(err, data) {
+      if(err) _this.serverless.cli.log(err);
+      else {
+        const secrets = JSON.parse(data);
 
-    const params = {
-      CiphertextBlob: new Buffer(secrets[this.options.name], 'base64'),
-    };
+        const params = {
+          CiphertextBlob: new Buffer(secrets[_this.options.name], 'base64'),
+        };
 
-    return this.provider.request(
-      'KMS',
-      'decrypt',
-      params,
-      this.options.stage, this.options.region
-    ).then((ret) => {
-      this.serverless.cli.log(`Decrypted text: ${ret.Plaintext.toString('utf-8')}`);
+        return _this.provider.request(
+          'KMS',
+          'decrypt',
+          params,
+          _this.options.stage, _this.options.region
+        ).then((ret) => {
+          _this.serverless.cli.log(`Decrypted text: ${ret.Plaintext.toString('utf-8')}`);
+        });
+      }
     });
   },
 };

--- a/lib/saveSecret.js
+++ b/lib/saveSecret.js
@@ -3,23 +3,83 @@
 const BbPromise = require('bluebird');
 const fs = require('fs');
 
+const aws = require('aws-sdk')
+
+function file_data(location, cb) {
+  if (fs.existsSync(location)) {
+    fs.readFile(location, 'utf8', cb)
+  } else {
+    cb(null, "{}")
+  }
+}
+
+function s3_data(location, cb) {
+  let matches = location.match(/s3:\/\/([^\/]*)\/(.*$)/);
+  let bucket = matches[1];
+  let key = matches[2]
+  let s3 = new aws.S3({apiVersion: '2006-03-01', signatureVersion: 'v4'});
+  s3.getObject({ 'Bucket': bucket, 'Key': key }, function(err, data) {
+    if(err) {
+      if(err.statusCode == 404) {
+        cb(null, "{}");
+      } else {
+        cb(err, data);
+      }
+    } else
+    {
+      cb(err, data.Body.toString());
+    }
+  });
+}
+
+function load(location, cb) {
+  if(location.startsWith('s3://')) {
+    return s3_data(location, cb);
+  } else if(location.startsWith('file://')) {
+    return file_data(location.substring(7), cb);
+  } else {
+    return file_data(location, cb);
+  }
+}
+
+function file_data_save(location, data, cb) {
+  fs.writeFile(location, data, cb);
+}
+
+function s3_data_save(location, data, kmsKeyId, cb) {
+  let matches = location.match(/s3:\/\/([^\/]*)\/(.*$)/);
+  let bucket = matches[1];
+  let key = matches[2]
+  let s3 = new aws.S3({apiVersion: '2006-03-01'});
+  s3.putObject({ 'Bucket': bucket, 'Key': key, 'Body': data, 'SSEKMSKeyId': kmsKeyId, 'ServerSideEncryption': 'aws:kms' }, cb);
+}
+
+function save(location, data, kmsKeyId, cb) {
+  if(location.startsWith('s3://')) {
+    return s3_data_save(location, data, kmsKeyId, cb);
+  } else if(location.startsWith('file://')) {
+    return file_data_save(location.substring(7), data, cb);
+  } else {
+    return file_data_save(location, data, cb);
+  }
+}
+
 module.exports = {
   saveSecret() {
-    if (!this.options.save) {
+    let _this = this;
+    if (!_this.options.save) {
       return BbPromise.resolve();
     }
-
-    let secrets = {};
-
-    if (fs.existsSync(this.secret_file)) {
-      secrets = JSON.parse(fs.readFileSync(this.secret_file, 'utf8'));
-    }
-    secrets['__slscrypt-region'] = this.options.region;
-    secrets[this.options.name] = this.cipherText;
-    fs.writeFileSync(this.secret_file, JSON.stringify(secrets, null, 2));
-
-    this.serverless.cli.log(`Successfully saved the secret that named "${this.options.name}"`);
-
-    return BbPromise.resolve();
+    load(_this.secret_location, function(err, data) {
+      if(err) return BbPromise.reject(err);
+      let secrets = JSON.parse(data);
+      secrets['__slscrypt-region'] = _this.options.region;
+      secrets[_this.options.name] = _this.cipherText;
+      save(_this.secret_location, JSON.stringify(secrets, null, 2), _this.serverless.service.custom.cryptKeyId, function(err) {
+        if(err) return BbPromise.reject(err);
+        _this.serverless.cli.log(`Successfully saved the secret that named "${_this.options.name}" to "${_this.secret_location}"`);
+        return BbPromise.resolve();
+      })
+    });
   },
 };

--- a/package.json
+++ b/package.json
@@ -43,8 +43,9 @@
     "tap": "^8.0.0"
   },
   "dependencies": {
-    "aws-sdk": "^2.6.13",
+    "aws-sdk": "^2.22.0",
     "bluebird": "^3.4.6",
+    "eslint-plugin-import": "^2.2.0",
     "fs-extra": "^1.0.0"
   }
 }


### PR DESCRIPTION
Add's an optional location parameter for cli that if s3:// is in it will try to save the secrets to the s3 bucket using the KMS key.

The plugin for lambda functions to get the secret requires a "location" parameter that must be specified now.  